### PR TITLE
Revert "Merge pull request #10 from ua-snap/fix_leaflet_wiredep"

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -183,8 +183,7 @@ module.exports = function (grunt) {
     wiredep: {
       app: {
         src: ['<%= yeoman.app %>/index.html'],
-        ignorePath:  /\.\.\//,
-        exclude: ['bower_components/leaflet/']
+        ignorePath:  /\.\.\//
       },
       test: {
         devDependencies: true,


### PR DESCRIPTION
This reverts commit 38be0b6b893e1d9f4af0932ae0b095ea6c8a8e42, reversing
changes made to 84fca424d26594663ec9ff315c2ad7e2ea434a99.

Reverses the PR that added the "exclude leaflet" portion of the Gruntfile.js. We will need to find a different solution if this problem still exists.