### PR TITLE
Reorder layers

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -72,7 +72,7 @@
 
     <!-- build:js(.) scripts/vendor.js -->
     <!-- bower:js -->
-    <script src="bower_components/jquery/dist/jquery.js"></script>
+    <script src="bower_components/jquery/jquery.js"></script>
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/bootstrap-sass-official/assets/javascripts/bootstrap.js"></script>
     <script src="bower_components/angular-animate/angular-animate.js"></script>
@@ -84,6 +84,8 @@
     <script src="bower_components/proj4/dist/proj4.js"></script>
     <script src="bower_components/leaflet-dist/leaflet.js"></script>
     <script src="bower_components/proj4leaflet/src/proj4leaflet.js"></script>
+    <script src="bower_components/jquery-ui/jquery-ui.js"></script>
+    <script src="bower_components/angular-ui-sortable/sortable.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/app/index.html
+++ b/app/index.html
@@ -94,6 +94,7 @@
         <script src="scripts/controllers/map.js"></script>
         <script src="scripts/directives/maplist.js"></script>
         <script src="scripts/services/map.js"></script>
+        <script src="scripts/services/basemap.js"></script>
         <!-- endbuild -->
 </body>
 </html>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -15,7 +15,8 @@ angular
     'ngResource',
     'ngRoute',
     'ngSanitize',
-    'ngTouch'
+    'ngTouch',
+    'ui.sortable'
   ])
   .config(function ($routeProvider, MapProvider) {
     $routeProvider

--- a/app/scripts/controllers/map.js
+++ b/app/scripts/controllers/map.js
@@ -23,11 +23,11 @@ angular.module('mapventureApp')
     Map.layers($routeParams.mapId)
       .success(function(data) {
         $scope.map = data;
-        $scope.addLayers();
-
         $scope.crs = BaseMap.getCRS($scope.map.srid);
 
         $scope.baselayer = BaseMap.getBaseLayer($scope.map.srid, geoserverUrl, $scope.crs.options.resolutions.length); 
+
+        $scope.addLayers();
 
         $scope.mapObj = L.map('snapmapapp', {
           center: [65, -150],
@@ -41,7 +41,14 @@ angular.module('mapventureApp')
         });
 
         new L.Control.Zoom({ position: 'topright' }).addTo($scope.mapObj);
-
+     
+        $scope.sortableOptions = {
+          stop: function() {
+            for(var i = 0; i < $scope.map.layers.length; i++) {
+              $scope.layers[$scope.map.layers[i].name].obj.setZIndex(i);
+            }
+          }    
+        };
     });
 
     $scope.addLayers = function() {

--- a/app/scripts/controllers/map.js
+++ b/app/scripts/controllers/map.js
@@ -18,35 +18,32 @@ angular.module('mapventureApp')
 
     var geoserverUrl = 'http://localhost:8080/geoserver/wms';
 
-    $scope.crs = BaseMap.getProjCRS(3413);
-
-    $scope.mapObj = L.map('snapmapapp', {
-      center: [65, -150],
-      zoom: 1,
-      crs: $scope.crs,
-      scrollWheelZoom: false,
-      zoomControl: false,
-      layers: [
-        L.tileLayer.wms(geoserverUrl, {
-          continuousWorld: true,
-          maxZoom: $scope.crs.options.resolutions.length,
-          minZoom: 0,
-          layers: 'natural_earth_base',
-          format: 'image/png',
-          version: '1.3'
-        })
-      ]
-    });
-
-    new L.Control.Zoom({ position: 'topright' }).addTo($scope.mapObj);
-
     $scope.layers = {};
 
     Map.layers($routeParams.mapId)
       .success(function(data) {
         $scope.map = data;
         $scope.addLayers();
-      });
+        console.log($scope.map.srid);
+
+        $scope.crs = BaseMap.getCRS($scope.map.srid);
+
+        $scope.baselayer = BaseMap.getBaseLayer($scope.map.srid, geoserverUrl, $scope.crs.options.resolutions.length); 
+
+        $scope.mapObj = L.map('snapmapapp', {
+          center: [65, -150],
+          zoom: 1,
+          crs: $scope.crs,
+          scrollWheelZoom: false,
+          zoomControl: false,
+          layers: [
+            $scope.baselayer
+          ]
+        });
+
+        new L.Control.Zoom({ position: 'topright' }).addTo($scope.mapObj);
+
+    });
 
     $scope.addLayers = function() {
       angular.forEach($scope.map.layers, function(layer) {

--- a/app/scripts/controllers/map.js
+++ b/app/scripts/controllers/map.js
@@ -13,21 +13,12 @@ angular.module('mapventureApp')
     '$http',
     '$routeParams',
     'Map',
-    function ($scope, $http, $routeParams, Map) {
+    'BaseMap',
+    function ($scope, $http, $routeParams, Map, BaseMap) {
 
     var geoserverUrl = 'http://localhost:8080/geoserver/wms';
 
-    $scope.crs = new L.Proj.CRS('EPSG:3338',
-      '+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
-      {
-        // This bit of magic came from a guide I found online and should be considered suspicious.
-        // TODO, figure out what the resolutions mean in the context of this code.
-        // GH#65
-        resolutions: [
-          8192, 4096, 2048, 1024, 512, 256, 128
-        ],
-        origin: [0, 0]
-      });
+    $scope.crs = BaseMap.getProjCRS(3413);
 
     $scope.mapObj = L.map('snapmapapp', {
       center: [65, -150],

--- a/app/scripts/controllers/map.js
+++ b/app/scripts/controllers/map.js
@@ -24,7 +24,6 @@ angular.module('mapventureApp')
       .success(function(data) {
         $scope.map = data;
         $scope.addLayers();
-        console.log($scope.map.srid);
 
         $scope.crs = BaseMap.getCRS($scope.map.srid);
 

--- a/app/scripts/services/basemap.js
+++ b/app/scripts/services/basemap.js
@@ -13,7 +13,7 @@ angular.module('mapventureApp')
     var service = {};
 
     service.getProjCRS = function(epsg_code) {
-      if (epsg_code == 3338) {
+      if (epsg_code === 3338) {
           return new L.Proj.CRS('EPSG:3338',
               '+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
               {
@@ -21,7 +21,7 @@ angular.module('mapventureApp')
                   origin: [0, 0]
               }
           );
-      } else if (epsg_code == 3413) {
+      } else if (epsg_code === 3413) {
           return new L.Proj.CRS('EPSG:3413',
               '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs',
               {

--- a/app/scripts/services/basemap.js
+++ b/app/scripts/services/basemap.js
@@ -12,16 +12,14 @@ angular.module('mapventureApp')
 
     var service = {};
 
-    service.getProjCRS = function(epsg_code) {
-      if (epsg_code === 3338) {
-          return new L.Proj.CRS('EPSG:3338',
-              '+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
-              {
-                  resolutions: [8192, 4096, 2048, 1024, 512, 256, 128],
-                  origin: [0, 0]
-              }
-          );
-      } else if (epsg_code === 3413) {
+    /**
+      Get CRS Function
+      Purpose: Used to generate the desired coordinate reference system for a particular map
+      Input: epsg_code - EPSG Code as integer value.
+      Output: Returns a new Leaflet CRS object using the correct options for the input EPSG code
+    */
+    service.getCRS = function(epsg_code) {
+      if (epsg_code === 'EPSG:3413') {
           return new L.Proj.CRS('EPSG:3413',
               '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs',
               {
@@ -29,6 +27,36 @@ angular.module('mapventureApp')
                   origin: [0, 0]
               }
           );
+      } else {
+          return new L.Proj.CRS('EPSG:3338',
+              '+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
+              {
+                  resolutions: [8192, 4096, 2048, 1024, 512, 256, 128],
+                  origin: [0, 0]
+              }
+          );
+      } 
+    };
+
+    /**
+      Get Base Layer Function
+      Purpose: Generates the base layer from a WMS layer provided by the input to the function.
+      Definition: Base layers are non-toggleable layers used to place other layers on top of.
+      Input: epsg_code - EPSG Code as integer value.
+             layerUrl - Full URL to web-accessible WMS service providing our imported baselayer.
+             maximumZoom - The maximum number of resolutions available from the created CRS.
+      Output: Returns a new Leaflet WMS layer object created from the layerURL input.
+    */
+    service.getBaseLayer = function(epsg_code, layerUrl, maximumZoom) {
+      if (epsg_code === 'EPSG:3338' || epsg_code === 'EPSG:3413') {
+        return new L.tileLayer.wms(layerUrl, {
+              continuousWorld: true,
+              maxZoom: maximumZoom, 
+              minZoom: 0,
+              layers: 'natural_earth_base',
+              format: 'image/png',
+              version: '1.3'
+        });
       }
     };
 

--- a/app/scripts/services/basemap.js
+++ b/app/scripts/services/basemap.js
@@ -1,0 +1,36 @@
+'use strict';
+
+/**
+ * @ngdoc service
+ * @name mapventureApp.BaseMap
+ * @description
+ * # BaseMap
+ * Factory in the mapventureApp.
+ */
+angular.module('mapventureApp')
+  .factory('BaseMap', function () {
+
+    var service = {};
+
+    service.getProjCRS = function(epsg_code) {
+      if (epsg_code == 3338) {
+          return new L.Proj.CRS('EPSG:3338',
+              '+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
+              {
+                  resolutions: [8192, 4096, 2048, 1024, 512, 256, 128],
+                  origin: [0, 0]
+              }
+          );
+      } else if (epsg_code == 3413) {
+          return new L.Proj.CRS('EPSG:3413',
+              '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs',
+              {
+                  resolutions: [8192,4096, 2048, 1024, 512, 256, 128],
+                  origin: [0, 0]
+              }
+          );
+      }
+    };
+
+    return service;
+  });

--- a/app/scripts/services/basemap.js
+++ b/app/scripts/services/basemap.js
@@ -19,9 +19,9 @@ angular.module('mapventureApp')
       Output: Returns a new Leaflet CRS object using the correct options for the input EPSG code
     */
     service.getCRS = function(epsg_code) {
-      if (epsg_code === 'EPSG:3413') {
-          return new L.Proj.CRS('EPSG:3413',
-              '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs',
+      if (epsg_code === 'EPSG:3572') {
+          return new L.Proj.CRS('EPSG:3572',
+              '+proj=laea +lat_0=90 +lon_0=-150 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs',
               {
                   resolutions: [8192,4096, 2048, 1024, 512, 256, 128],
                   origin: [0, 0]

--- a/app/scripts/services/basemap.js
+++ b/app/scripts/services/basemap.js
@@ -48,7 +48,6 @@ angular.module('mapventureApp')
       Output: Returns a new Leaflet WMS layer object created from the layerURL input.
     */
     service.getBaseLayer = function(epsg_code, layerUrl, maximumZoom) {
-      if (epsg_code === 'EPSG:3338' || epsg_code === 'EPSG:3413') {
         return new L.tileLayer.wms(layerUrl, {
               continuousWorld: true,
               maxZoom: maximumZoom, 
@@ -57,7 +56,6 @@ angular.module('mapventureApp')
               format: 'image/png',
               version: '1.3'
         });
-      }
     };
 
     return service;

--- a/app/styles/map.scss
+++ b/app/styles/map.scss
@@ -15,6 +15,8 @@
 
   .layer {
     margin: 5px 0;
+    cursor: pointer;
+    cursor: hand;
     .btn {
       margin: 0 5px 0 0;
     }

--- a/app/views/map.html
+++ b/app/views/map.html
@@ -1,6 +1,7 @@
 <div class="layer-menu">
   <h2>{{ map.title }}</h2>
-  <div class="layer" data-toggle="buttons" ng-repeat="layer in map.layers">
+  <div ui-sortable="sortableOptions" ng-model="map.layers">
+  <div class="layer" data-toggle="buttons" ng-repeat="layer in map.layers"> 
     <label class="btn btn-primary" ng-click="$parent.toggleLayer(layer.name)">
       <span class="glyphicon glyphicon-eye-close" ng-hide="$parent.layers[layer.name].visible"></span>
       <span class="glyphicon glyphicon-eye-open" ng-show="$parent.layers[layer.name].visible"></span>
@@ -8,5 +9,6 @@
     </label>
     {{ layer.title }}
   </div>
+</div>
 </div>
 <div id="snapmapapp"></div>

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,9 @@
     "angular-route": "^1.3.0",
     "angular-sanitize": "^1.3.0",
     "angular-touch": "^1.3.0",
-    "proj4leaflet": "~0.7.1"
+    "proj4leaflet": "~0.7.1",
+    "jquery-ui": "~1.11.4",
+    "angular-ui-sortable": "~0.13.4"
   },
   "devDependencies": {
     "angular-mocks": "^1.3.0"

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       // bower:js
-      'bower_components/jquery/dist/jquery.js',
+      'bower_components/jquery/jquery.js',
       'bower_components/angular/angular.js',
       'bower_components/bootstrap-sass-official/assets/javascripts/bootstrap.js',
       'bower_components/angular-animate/angular-animate.js',
@@ -34,6 +34,8 @@ module.exports = function(config) {
       'bower_components/proj4/dist/proj4.js',
       'bower_components/leaflet-dist/leaflet.js',
       'bower_components/proj4leaflet/src/proj4leaflet.js',
+      'bower_components/jquery-ui/jquery-ui.js',
+      'bower_components/angular-ui-sortable/sortable.js',
       'bower_components/angular-mocks/angular-mocks.js',
       // endbower
       "app/scripts/**/*.js",

--- a/test/spec/services/basemap.js
+++ b/test/spec/services/basemap.js
@@ -1,0 +1,18 @@
+'use strict';
+
+describe('Service: BaseMap', function () {
+
+  // load the service's module
+  beforeEach(module('mapventureApp'));
+
+  // instantiate service
+  var BaseMap;
+  beforeEach(inject(function (_BaseMap_) {
+    BaseMap = _BaseMap_;
+  }));
+
+  it('should do something', function () {
+    expect(!!BaseMap).toBe(true);
+  });
+
+});


### PR DESCRIPTION
This PR contains two branches that are in a state that they can be merged into master. The first is the addition of the BaseMap factory for creating the base layer of a map. This currently only adds the Natural Earth base layer to all maps, but can very quickly be updated to have a map ID or projection provide a different base layer.

The second addition is the ability to reorganize layers in the Map window so that their ordering from bottom to top indicates which layer will display on top of the others. You can drag and drop the layer names / divs to have them dynamically update on the map.