### PR TITLE
Basemap factory

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -184,7 +184,12 @@ module.exports = function (grunt) {
       app: {
         src: ['<%= yeoman.app %>/index.html'],
         ignorePath:  /\.\.\//,
-        exclude: ['bower_components/leaflet/']
+        exclude: ['bower_components/leaflet/'],
+        overrides: {
+          'proj4': {
+            main: 'dist/proj4-src.js'
+          }
+        }
       },
       test: {
         devDependencies: true,

--- a/app/index.html
+++ b/app/index.html
@@ -72,7 +72,7 @@
 
     <!-- build:js(.) scripts/vendor.js -->
     <!-- bower:js -->
-    <script src="bower_components/jquery/jquery.js"></script>
+    <script src="bower_components/jquery/dist/jquery.js"></script>
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/bootstrap-sass-official/assets/javascripts/bootstrap.js"></script>
     <script src="bower_components/angular-animate/angular-animate.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -81,7 +81,7 @@
     <script src="bower_components/angular-route/angular-route.js"></script>
     <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
     <script src="bower_components/angular-touch/angular-touch.js"></script>
-    <script src="bower_components/proj4/dist/proj4.js"></script>
+    <script src="bower_components/proj4/dist/proj4-src.js"></script>
     <script src="bower_components/leaflet-dist/leaflet.js"></script>
     <script src="bower_components/proj4leaflet/src/proj4leaflet.js"></script>
     <!-- endbower -->

--- a/app/scripts/controllers/map.js
+++ b/app/scripts/controllers/map.js
@@ -27,7 +27,7 @@ angular.module('mapventureApp')
 
         $scope.crs = BaseMap.getCRS($scope.map.srid);
 
-        $scope.baselayer = BaseMap.getBaseLayer($scope.map.srid, geoserverUrl, $scope.crs.options.resolutions.length); 
+        $scope.baselayer = BaseMap.getBaseLayer($scope.map.srid, geoserverUrl);
 
         $scope.mapObj = L.map('snapmapapp', {
           center: [65, -150],

--- a/app/scripts/services/basemap.js
+++ b/app/scripts/services/basemap.js
@@ -20,13 +20,21 @@ angular.module('mapventureApp')
     */
     service.getCRS = function(epsg_code) {
       if (epsg_code === 'EPSG:3572') {
-          return new L.Proj.CRS('EPSG:3572',
+          var proj = new L.Proj.CRS('EPSG:3572',
               '+proj=laea +lat_0=90 +lon_0=-150 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs',
               {
-                  resolutions: [8192,4096, 2048, 1024, 512, 256, 128],
+                  resolutions: [8192, 4096, 2048, 1024, 512, 256, 128],
                   origin: [0, 0]
               }
           );
+
+          // trust me.
+          // Without this (= pi/2), proj4js returns an undefined
+          // value for tiles requested at the North Pole and
+          // it causes a runtime exception.
+          proj.projection._proj.oProj.phi0 = 1.5708;
+          return proj;
+
       } else {
           return new L.Proj.CRS('EPSG:3338',
               '+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
@@ -35,7 +43,7 @@ angular.module('mapventureApp')
                   origin: [0, 0]
               }
           );
-      } 
+      }
     };
 
     /**
@@ -48,14 +56,19 @@ angular.module('mapventureApp')
       Output: Returns a new Leaflet WMS layer object created from the layerURL input.
     */
     service.getBaseLayer = function(epsg_code, layerUrl, maximumZoom) {
-        return new L.tileLayer.wms(layerUrl, {
-              continuousWorld: true,
-              maxZoom: maximumZoom, 
-              minZoom: 0,
-              layers: 'natural_earth_base',
-              format: 'image/png',
-              version: '1.3'
-        });
+
+      var layerName = (epsg_code === 'EPSG:3572') ? 'ne_10m_coastline' : 'natural_earth_base';
+
+      return new L.tileLayer.wms(layerUrl, {
+            continuousWorld: true,
+            maxZoom: maximumZoom,
+            transparent: true,
+            minZoom: 0,
+            layers: layerName,
+            format: 'image/png',
+            version: '1.3',
+            zIndex: 10000
+      });
     };
 
     return service;

--- a/app/scripts/services/basemap.js
+++ b/app/scripts/services/basemap.js
@@ -57,17 +57,37 @@ angular.module('mapventureApp')
     */
     service.getBaseLayer = function(epsg_code, layerUrl, maximumZoom) {
 
-      var layerName = (epsg_code === 'EPSG:3572') ? 'ne_10m_coastline' : 'natural_earth_base';
+      // Real cheap for the moment.
+      // The `epsg_code` comes from the `SRS` field of the map object
+      // we get back from the MapLayers API endpoint.  It defaults
+      // to 4326, and you need to use the Django admin to change it,
+      // this is just a safety catch.
+      if(epsg_code === 'EPSG:4326') { epsg_code = 'EPSG:3338'; }
+
+      // When we add a 3rd map, we'll need to figure
+      // out where to refactor this logic.
+      var layerConfiguration = {
+        'EPSG:3572': {
+          baseLayerName: 'ne_10m_coastline',
+          zIndex: 10000,
+          transparent: true
+        },
+        'EPSG:3338': {
+          baseLayerName: 'natural_earth_base',
+          zIndex: 0,
+          transparent: false
+        }
+      };
 
       return new L.tileLayer.wms(layerUrl, {
             continuousWorld: true,
             maxZoom: maximumZoom,
-            transparent: true,
+            transparent: layerConfiguration[epsg_code].transparent,
             minZoom: 0,
-            layers: layerName,
+            layers: layerConfiguration[epsg_code].baseLayerName,
             format: 'image/png',
             version: '1.3',
-            zIndex: 10000
+            zIndex: layerConfiguration[epsg_code].zIndex
       });
     };
 

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,8 @@
     "angular-route": "^1.3.0",
     "angular-sanitize": "^1.3.0",
     "angular-touch": "^1.3.0",
-    "proj4leaflet": "~0.7.1"
+    "proj4leaflet": "~0.7.1",
+    "proj4": "~2.3.12"
   },
   "devDependencies": {
     "angular-mocks": "^1.3.0"
@@ -25,5 +26,8 @@
         "dist/js/bootstrap.js"
       ]
     }
+  },
+  "resolutions": {
+    "proj4": "~2.3.12"
   }
 }

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       // bower:js
-      'bower_components/jquery/jquery.js',
+      'bower_components/jquery/dist/jquery.js',
       'bower_components/angular/angular.js',
       'bower_components/bootstrap-sass-official/assets/javascripts/bootstrap.js',
       'bower_components/angular-animate/angular-animate.js',


### PR DESCRIPTION
Isolates base maps from core `Map` controller as a service.

Wires in `proj4.js` in a non-minified version for ease of tracing bugs (it gets minified for `dist` anyhow).

Also points the base layer for the single 3572 map (NCEP) to use a vector overlay.
