### PR TITLE
Reverse the order that layers are displayed when re-ordered.

### DIFF
--- a/app/scripts/controllers/map.js
+++ b/app/scripts/controllers/map.js
@@ -48,7 +48,7 @@ app.controller('MapCtrl', [
         $scope.sortableOptions = {
           stop: function() {
             for(var i = 0; i < $scope.map.layers.length; i++) {
-              $scope.layers[$scope.map.layers[i].name].obj.setZIndex(i);
+              $scope.layers[$scope.map.layers[i].name].obj.setZIndex($scope.map.layers.length - i);
             }
           }
         };


### PR DESCRIPTION
This will make the layers ordered in Z level from top to bottom, rather than from bottom to top as it is currently.