### PR TITLE
Fixes issue #29

### DIFF
--- a/app/scripts/controllers/map.js
+++ b/app/scripts/controllers/map.js
@@ -24,7 +24,7 @@ app.controller('MapCtrl', [
       Map.layers($routeParams.mapId).success(function(data) {
         $scope.map = data;
         $scope.crs = BaseMap.getCRS($scope.map.srid);
-        $scope.baselayer = BaseMap.getBaseLayer($scope.map.srid, geoserverUrl);
+        $scope.baselayer = BaseMap.getBaseLayer($scope.map.srid, geoserverUrl, $scope.crs.options.resolutions.length);
         $scope.addLayers();
 
         $scope.mapObj = L.map('snapmapapp', {


### PR DESCRIPTION
There was a missing argument for the function getBaseLayer in the BaseMap factory. This missing argument set the number of zoom levels available, so this resulted in the zoom buttons both resulting in the zeroth entry in the list, which is the highest resolution of the map. I re-entered that missing argument and the map now zooms in and out properly on the basemap.

This resolves issue #29.