### PR TITLE
Allows for the same layer to be loaded on both maps.

### DIFF
--- a/app/scripts/controllers/map.js
+++ b/app/scripts/controllers/map.js
@@ -103,27 +103,28 @@ app.controller('MapCtrl', [
           stop: function() {
             for(var i = 0; i < $scope.map.layers.length; i++) {
               $scope.layers[$scope.map.layers[i].name].obj.setZIndex($scope.map.layers.length - i);
+              $scope.layers[$scope.map.layers[i].name].secondObj.setZIndex($scope.map.layers.length - i);
             }
           }
         };
 
       new L.Control.Zoom({ position: 'topright' }).addTo($scope.mapObj);
+      new L.Control.Zoom({ position: 'topright' }).addTo($scope.secondMapObj);
 
       });
 
       $scope.showSecondLayer = function(layerName) {
-          $scope.layers[layerName].obj.addTo($scope.secondMapObj);
+          $scope.layers[layerName].secondObj.addTo($scope.secondMapObj);
           $scope.layers[layerName].secondvisible = true;
       };
 
       $scope.hideSecondLayer = function(layerName) {
-          $scope.secondMapObj.removeLayer($scope.layers[layerName].obj);
+          $scope.secondMapObj.removeLayer($scope.layers[layerName].secondObj);
           $scope.layers[layerName].secondvisible = false;
       };
 
       $scope.toggleSecondLayer = function(layerName) {
-        if($scope.secondMapObj.hasLayer($scope.layers[layerName].obj) === false) {
-          $scope.hideLayer(layerName);
+        if($scope.secondMapObj.hasLayer($scope.layers[layerName].secondObj) === false) {
           $scope.showSecondLayer(layerName);
         } else {
           $scope.hideSecondLayer(layerName);
@@ -137,6 +138,15 @@ app.controller('MapCtrl', [
         layer.name = layer.name.replace('geonode:','');
         $scope.layers[layer.name] = {};
         $scope.layers[layer.name].obj = L.tileLayer.wms(geoserverUrl, {
+          continuousWorld: true,
+          layers: layer.name,
+          name: layer.name,
+          transparent: true,
+          format: 'image/png',
+          version: '1.3',
+          visible: false
+        });
+        $scope.layers[layer.name].secondObj = L.tileLayer.wms(geoserverUrl, {
           continuousWorld: true,
           layers: layer.name,
           name: layer.name,
@@ -161,7 +171,6 @@ app.controller('MapCtrl', [
 
     $scope.toggleLayer = function(layerName) {
       if($scope.mapObj.hasLayer($scope.layers[layerName].obj) === false) {
-        $scope.hideSecondLayer(layerName);
         $scope.showLayer(layerName);
       } else {
         $scope.hideLayer(layerName);
@@ -204,6 +213,14 @@ app.controller('MapCtrl', [
       });
     });
 
+
+    $scope.$on('start-tour-dual-maps', function(event) {
+      $scope.$evalAsync(function() {
+        if ($scope.dualMaps === true) {
+          $scope.showDualMaps();
+        }
+      });
+    });
 
     $scope.$on('show-dual-maps', function(event) {
       $scope.$evalAsync(function() {

--- a/app/scripts/directives/tour.js
+++ b/app/scripts/directives/tour.js
@@ -20,6 +20,8 @@ app.directive('tour', ['$timeout', 'Map', function ($timeout, Map) {
             content: "Hello! Welcome to the NCEP map. This tour will show you around.",
             onShow: function() {
               scope.$broadcast('show-layers', []);
+              scope.$broadcast('show-second-layers', []);
+              scope.$broadcast('start-tour-dual-maps');
             }
           },
           {
@@ -78,6 +80,7 @@ app.directive('tour', ['$timeout', 'Map', function ($timeout, Map) {
             element: "#showDualMaps",
             content: "Once clicked, additional buttons are added to the layer menu.",
             onShow: function() {
+              scope.$broadcast('start-tour-dual-maps');
               scope.$broadcast('show-dual-maps', []);
             },
             onHide: function() {
@@ -146,6 +149,8 @@ app.directive('tour', ['$timeout', 'Map', function ($timeout, Map) {
             content: "Hello! Welcome to the IEM map. This tour will show you around the IEM map.",
             onShow: function() {
               scope.$broadcast('show-layers', []);
+              scope.$broadcast('show-second-layers', []);
+              scope.$broadcast('start-tour-dual-maps');
             }
           },
           {
@@ -204,6 +209,7 @@ app.directive('tour', ['$timeout', 'Map', function ($timeout, Map) {
             element: "#showDualMaps",
             content: "Once clicked, additional buttons are added to the layer menu.",
             onShow: function() {
+              scope.$broadcast('start-tour-dual-maps');
               scope.$broadcast('show-dual-maps', []);
             },
             onHide: function() {


### PR DESCRIPTION
This patch allows for the same layer to be loaded on both maps when in dual map mode. This also closes dual map mode and turns off all second map layers when a tour starts.
https://github.com/ua-snap/mapventure/issues/62
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapventure/71)
<!-- Reviewable:end -->