### PR TITLE
Assign max zoom level, fix zoom jump bug

### DIFF
--- a/app/scripts/controllers/map.js
+++ b/app/scripts/controllers/map.js
@@ -87,8 +87,8 @@ app.controller('MapCtrl', [
             center: [65, -150],
             zoom: 1,
             crs: crs,
-            scrollWheelZoom: false,
-            zoomControl: false
+            zoomControl: false,
+            scrollWheelZoom: false
           }, BaseMap.getMapOptions($scope.map.id)
         );
 
@@ -159,6 +159,7 @@ app.controller('MapCtrl', [
           $scope.hideSecondLayer(layerName);
         }
       };
+
 
     $scope.addLayers = function() {
       angular.forEach($scope.map.layers, function(layer) {

--- a/app/scripts/services/basemap.js
+++ b/app/scripts/services/basemap.js
@@ -16,7 +16,7 @@ angular.module('mapventureApp')
     // to a visible state upon map load.
     // TODO: refactor to use slug/UUID
     service.getDefaultLayers = function(mapId) {
-      var defaultLayers = ['active_fires'];
+      var defaultLayers = ['fire_perimeters_2016'];
       return (5 === mapId) ? defaultLayers : [];
     }
 
@@ -47,7 +47,7 @@ angular.module('mapventureApp')
           return new L.Proj.CRS('EPSG:3338',
               '+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
               {
-                  resolutions: [8192, 4096, 2048, 1024, 512, 256, 128],
+                  resolutions: [65536, 32768, 16384, 8192, 4096, 2048, 1024, 512, 256, 128, 64, 32, 16],
                   origin: [0, 0]
               }
           );
@@ -64,7 +64,8 @@ angular.module('mapventureApp')
     service.getMapOptions = function(mapId) {
       var mapOptions = {
         zoom: 3,
-        minZoom: 3,
+        minZoom: 6,
+        maxZoom: 11,
         maxBounds: new L.latLngBounds(
           L.latLng(72, -165),
           L.latLng(50, -145)
@@ -106,17 +107,19 @@ angular.module('mapventureApp')
         },
         'EPSG:3338': {
           layers: 'MapProxy:osm',
-          transparent: true
+          transparent: true,
+          minZoom: 6,
+          maxZoom: 11
         }
       };
 
       var baseConfiguration = {
         format: 'image/png',
         version: '1.3',
-        minZoom: 0,
-        maxZoom: 18,
+        minZoom: 6,
+        maxZoom: 11,
         continuousWorld: true, // needed for non-3857 projs
-        noWrap: false, // may be needed for non-3857 projs
+        noWrap: true, // may be needed for non-3857 projs
         zIndex: null
       };
 

--- a/app/scripts/services/basemap.js
+++ b/app/scripts/services/basemap.js
@@ -16,7 +16,7 @@ angular.module('mapventureApp')
     // to a visible state upon map load.
     // TODO: refactor to use slug/UUID
     service.getDefaultLayers = function(mapId) {
-      var defaultLayers = ['fire_perimeters_2016'];
+      var defaultLayers = ['active_fires'];
       return (5 === mapId) ? defaultLayers : [];
     }
 


### PR DESCRIPTION
When the map was zoomed in, it would 'skip' to an invalid zoom level.  This was because the `resolutions` array defined in the CRS didn't have enough elements in it and so things sort of broke down in Proj4Leaflet.  This isn't exactly a bug in that code, though there could be more meaningful errors thrown, because there is a definite and purposeful relationship between the `resolutions` array and the zoom levels.  I adjusted the zoom levels and expanded the resolutions array to address the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapventure/84)
<!-- Reviewable:end -->
