### PR TITLE
Refs #156, enable proper cache behavior

### DIFF
--- a/app/scripts/controllers/map.js
+++ b/app/scripts/controllers/map.js
@@ -201,17 +201,19 @@ app.controller('MapCtrl', [
         $scope.layers[layer.name] = {};
         $scope.layers[layer.name].obj = L.tileLayer.wms(GEOSERVER_WMS_URL, {
           continuousWorld: true,
-          layers: layer.name,
+          layers: 'geonode:' + layer.name,
           name: layer.name,
           transparent: true,
+          tiled: 'true',
           format: 'image/png',
           version: '1.3',
           visible: false
         });
         $scope.layers[layer.name].secondObj = L.tileLayer.wms(GEOSERVER_WMS_URL, {
           continuousWorld: true,
-          layers: layer.name,
+          layers: 'geonode:' + layer.name,
           name: layer.name,
+          tiled: 'true',
           transparent: true,
           format: 'image/png',
           version: '1.3',

--- a/app/scripts/maps/alaska-wildfires/controller.js
+++ b/app/scripts/maps/alaska-wildfires/controller.js
@@ -17,15 +17,17 @@ app.controller('AlaskaWildfiresCtrl', [
   '$http',
   function($scope, Map, $http) {
 
-    // Some configuration for this map object.
-    // (In version history, this used to be
-    // in a `basemap` Service).
     $scope.defaultLayers = ['active_fires'];
     $scope.crs = new L.Proj.CRS('EPSG:3338',
       '+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
         {
           resolutions: [65536, 32768, 16384, 8192, 4096, 2048, 1024, 512, 256, 128, 64, 32, 16],
-          origin: [0, 0]
+
+          // Origin should be lower-left coordinate
+          // in projected space.  Use GeoServer to
+          // find this:
+          // TileSet > Gridset Bounds > compute from maximum extent of SRS
+          origin: [-4648005.934316417, 444809.882955059],
         }
     );
 
@@ -47,7 +49,6 @@ app.controller('AlaskaWildfiresCtrl', [
       format: 'image/png',
       version: '1.3',
       continuousWorld: true, // needed for non-3857 projs
-      noWrap: true, // may be needed for non-3857 projs
       zIndex: null
     };
 

--- a/app/scripts/maps/default/controller.js
+++ b/app/scripts/maps/default/controller.js
@@ -65,7 +65,12 @@ angular.module('mapventureApp')
         '+proj=laea +lat_0=90 +lon_0=-150 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs',
         {
           resolutions: [8192, 4096, 2048, 1024, 512, 256, 128],
-          origin: [0, 0]
+
+          // Origin should be lower-left coordinate
+          // in projected space.  Use GeoServer to
+          // find this:
+          // TileSet > Gridset Bounds > compute from maximum extent of SRS
+          origin: [-4234288.146966308, -4234288.146966307]
         }
       );
 
@@ -85,12 +90,12 @@ angular.module('mapventureApp')
 
       // Base layer configuration for pan-Arctic map.
       var baseConfiguration = {
-        layers: 'ne_10m_coastline',
+        layers: 'geonode:ne_10m_coastline',
         transparent: true,
         format: 'image/png',
         version: '1.3',
+        tiled: 'true',
         continuousWorld: true, // needed for non-3857 projs
-        noWrap: true, // may be needed for non-3857 projs
         zIndex: null
       };
 


### PR DESCRIPTION
Changes to `origin` definitions in base layers, and adds `TILED=true` so that the automatic WMS passthrough feature in GeoWebCache / GeoServer can function.  Some server-side configuration is also required, see [here](https://gist.github.com/brucecrevensten/a16a554ee1c64d9ac475a1468e94f508).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapventure/158)
<!-- Reviewable:end -->
