### PR TITLE
Fixes #133, broken behavior when clicking on multiple popup markers

### DIFF
--- a/app/scripts/maps/alaska-wildfires/controller.js
+++ b/app/scripts/maps/alaska-wildfires/controller.js
@@ -56,6 +56,18 @@ app.controller('AlaskaWildfiresCtrl', [
       return new L.tileLayer.wms(Map.geoserverWmsUrl(), baseConfiguration);
     };
 
+    // Is the map currently zoomed in to a marker?
+    // This is true if the
+    $scope.firePopopIsOpen = function() {
+      if(
+        undefined === $scope.zoomLevel &&
+        undefined === $scope.mapCenter
+        ) {
+        return false;
+      }
+      return true;
+    };
+
     // This function loads the additional fire polygons
     $scope.onLoad = function(mapObj, secondMapObj) {
 
@@ -121,32 +133,30 @@ app.controller('AlaskaWildfiresCtrl', [
                   riseOnHover: true
                 })
               .on('click',
-                function zoomToFirePolygon() {
-                  if (undefined === $scope.zoomLevel &&
-                    undefined === $scope.mapCenter
-                  ) {
-                    $scope.minimizeMenu();
+                function zoomToFirePolygon(e) {
+                  if ($scope.firePopopIsOpen()) {
                     $scope.zoomLevel = $scope.mapObj.getZoom();
                     $scope.mapCenter = $scope.mapObj.getCenter();
-                    $scope.mapObj.fitBounds(layer.getBounds(),
-                      {
-                        animate: true,
-                        maxZoom: 9
-                      }
-                    );
                     $scope.$apply();
                   }
+                  $scope.mapObj.fitBounds(layer.getBounds(),
+                    {
+                      animate: true,
+                      maxZoom: 9
+                    }
+                  );
                 }
               )
               .bindPopup(popupContents, popupOptions)
               .on('popupclose',
-                function restoreZoomLevel() {
-                  $scope.minimizeMenu();
-                  $scope.mapObj.setZoom($scope.zoomLevel);
-                  $scope.mapObj.panTo($scope.mapCenter);
-                  $scope.zoomLevel = undefined;
-                  $scope.mapCenter = undefined;
-                  $scope.$apply();
+                function restoreZoomLevel(e) {
+                  if (false !== $scope.firePopopIsOpen()) {
+                    $scope.mapObj.setZoom($scope.zoomLevel);
+                    $scope.mapObj.panTo($scope.mapCenter);
+                    $scope.zoomLevel = undefined;
+                    $scope.mapCenter = undefined;
+                    $scope.$apply();
+                  }
                 }
               )
               .addTo($scope.mapObj);


### PR DESCRIPTION
This commit changes some things to fix buggy behavior:

 * Clicking to zoom in on a marker no longer hides the sidebar
 * Clicking multiple popups in a row stays zoomed in, does not break the interface
 * Close button no longer navigates to root menu of angular route
 * map no longer zooms/pans to max extent when you close the last popup

Basically, trading off fancy-but-buggy behavior that needs more work & thought for its implementation and making things more simple but reliable.  We can add tickets to restore the fancier zoom/pan and such if requested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapventure/165)
<!-- Reviewable:end -->
