### PR TITLE
Fixes #194, make dividing line clearer between split maps

### DIFF
--- a/app/scripts/directives/menu-toggle.js
+++ b/app/scripts/directives/menu-toggle.js
@@ -11,7 +11,7 @@ angular.module('mapventureApp')
     return {
       templateUrl: 'views/menuToggle.html',
       restrict: 'E',
-      link: function postLink(scope, element, attrs) {
+      link: function postLink() {
       }
     };
   });

--- a/app/styles/map.scss
+++ b/app/styles/map.scss
@@ -91,7 +91,7 @@
     position: absolute;
     width: 50%;
     right: 50%;
-    border-right: 1px solid #888;
+    border-right: 2px solid rgba(0, 0, 0, .5);
   }
 
   #secondmap {


### PR DESCRIPTION
Also cleans up a JSHint violation with unused variables in the `menu-toggle` directive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapventure/204)
<!-- Reviewable:end -->
