### PR TITLE
Round up to the nearest acre for total acres burned on Fire Map.

### DIFF
--- a/app/scripts/maps/alaska-wildfires/controller.js
+++ b/app/scripts/maps/alaska-wildfires/controller.js
@@ -164,7 +164,7 @@ app.controller('AlaskaWildfiresCtrl', [
               ')(
                 {
                   title: feature.properties.NAME,
-                  acres: feature.properties.ACRES + ' acres',
+                  acres: Math.ceil(feature.properties.ACRES) + ' acres',
                   cause: feature.properties.GENERALCAU || 'Unknown',
                   updated: moment.utc(
                       moment.unix(


### PR DESCRIPTION
Resolves GH issue #252

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapventure/260)
<!-- Reviewable:end -->
