### PR TITLE
Fixes #267, edge of map visible on default viewport for large screens.

### DIFF
--- a/app/scripts/maps/alaska-wildfires/controller.js
+++ b/app/scripts/maps/alaska-wildfires/controller.js
@@ -38,7 +38,7 @@ app.controller('AlaskaWildfiresCtrl', [
       maxZoom: 20,
       center: [65, -158.5],
       maxBounds: new L.latLngBounds(
-        L.latLng(71.3, -200),
+        L.latLng(71.3, -220),
         L.latLng(51, -128)
       )
     };


### PR DESCRIPTION
The underlying issue here is that white border is actually the extent of the map, which is bounded according to (more or less) the extent of AK Albers on the server side.  You can adjust the Leaflet object's maxBounds, which will shuffle the default center of the map somewhat, but it's a little odd/fiddly.

Craig can you check this out?  I recreated the issue by switching my laptop to use native resolution, which is more, but you may be seeing something different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapventure/271)
<!-- Reviewable:end -->
