### PR TITLE
Fixes #339, align z-index between tour, graph, and info sidebar

### DIFF
--- a/app/scripts/maps/alaska-wildfires/alaska-wildfires.scss
+++ b/app/scripts/maps/alaska-wildfires/alaska-wildfires.scss
@@ -105,7 +105,7 @@
     height: 100%;
     width: 100%;
     background-color: rgba(150, 168, 48, 0.8);
-    z-index: 5000;
+    z-index: 3000;
     > div {
       padding: 2rem;
       background-color: rgba(255, 255, 255, .8);

--- a/app/styles/map.scss
+++ b/app/styles/map.scss
@@ -201,6 +201,10 @@
   background-color: #fff;
 }
 
+.leaflet-sidebar {
+  z-index: 4500;
+}
+
 .popover[class*="tour-"] {
-  z-index: 6000;
+  z-index: 4000;
 }


### PR DESCRIPTION
This change prevents the Tour step from overlapping the Info Sidebar but keeps it above the Fire History Graph.

When testing this, what we want to see is that the Tour steps are always visible (on top of all other elements) when desired, but are *behind* both the main splash screen (the one you see when reloading the page), and the Information Sidebar that the user is prompted to open during the "What do the colors mean?" step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapventure/345)
<!-- Reviewable:end -->
