### PR TITLE
Fixes #329, prevent both start/continue tour text showing at once

### DIFF
--- a/app/views/mapSplashScreen.html
+++ b/app/views/mapSplashScreen.html
@@ -4,7 +4,7 @@
     <div class="buttons">
       <button type="button" class="btn btn-lg btn-success" ng-click="hideSplash=true; startTour(tour._current)" ng-disabled="showMapButtonDisabled" disabled="disabled">
         <span ng-show="tour._current == null || tour._current == undefined">Take a tour of this map&hellip;</span>
-        <span ng-show="tour._current >= 0">Continue tour&hellip;</span>
+        <span ng-show="tour._current != null && tour._current >= 0">Continue tour&hellip;</span>
       </button>
       <a ng-click="hideSplash=true; endTour()" ng-disabled="showMapButtonDisabled" disabled="disabled">
         No thanks, just show me the map.


### PR DESCRIPTION
To test this, open a browser where you can delete all history and (crucially) local storage.  Clear everything.  Then load the Fire map and ensure that it doesn't display "Take a tour..." alongside "Continue tour...".  The problem was that `null >= 0` compares to True, so if the LocalStorage returned `null` from a fetch operation this failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapventure/346)
<!-- Reviewable:end -->
