### PR TITLE
Fixes #385, add confirmation step in production build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,6 +14,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks("grunt-jscs");
   grunt.loadNpmTasks('grunt-sass-globbing');
   grunt.loadNpmTasks('grunt-version');
+  grunt.loadNpmTasks('grunt-confirm');
 
   // Time how long tasks take. Can help when optimizing build times
   require('time-grunt')(grunt);
@@ -33,6 +34,36 @@ module.exports = function (grunt) {
 
   // Define the configuration for all the tasks
   grunt.initConfig({
+    confirm: {
+      build: {
+        options: {
+          // Static text.
+          question: function() {
+            var text = 'Check that these env variables are correct for building MV for production:\n\n';
+            text += 'GOOGLE_ANALYTICS_TOKEN: "' + process.env.GOOGLE_ANALYTICS_TOKEN + '"\n';
+            text += 'GEONODE_URL: "' + process.env.GEONODE_URL + '"\n';
+            text += 'GEOSERVER_URL: "' + process.env.GEOSERVER_URL + '"\n';
+            text += 'FIRE_FEATURES_URL: "' + process.env.FIRE_FEATURES_URL + '"\n';
+            text += 'FIRE_TIME_SERIES_URL: "' + process.env.FIRE_TIME_SERIES_URL + '"\n';
+            text += 'LEAFLET_IMAGE_PATH: "' + process.env.MV_LEAFLET_IMAGE_PATH + '"\n\n';
+            text += 'OK?  y/n';
+            return text;
+          },
+          input: '_key:y'
+        }
+      },
+      analytics: {
+        options: {
+          question: function() {
+            if(process.env.GOOGLE_ANALYTICS_TOKEN) {
+              return false; // It's set, it's OK
+            }
+            return 'The Google Analytics token is unset, are you sure you want to build without it?\n\nOK?  y/n';
+          },
+          input: '_key:y'
+        }
+      }
+    },
 
     version: {
       defaults: {
@@ -226,6 +257,7 @@ module.exports = function (grunt) {
         },
         constants: {
           ENV: {
+            GOOGLE_ANALYTICS_TOKEN: process.env.GOOGLE_ANALYTICS_TOKEN,
             GEONODE_URL: process.env.GEONODE_URL,
             GEOSERVER_URL: process.env.GEOSERVER_URL,
             FIRE_FEATURES_URL: process.env.FIRE_FEATURES_URL,
@@ -573,6 +605,7 @@ module.exports = function (grunt) {
     'useminPrepare',
     'ngconstant:development',
     'ngconstant:production',
+    'confirm',
     'sass_globbing', // Needs to come before concurrent:dist
     'concurrent:dist',
     'autoprefixer',

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "grunt-angular-templates": "^0.5.7",
     "grunt-autoprefixer": "^2.0.0",
     "grunt-concurrent": "^1.0.0",
+    "grunt-confirm": "1.0.7",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-compass": "^1.0.0",
     "grunt-contrib-concat": "^0.5.0",
@@ -20,22 +21,22 @@
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-jscs": "~2.8.0",
     "grunt-filerev": "^2.1.2",
     "grunt-google-cdn": "^0.4.3",
+    "grunt-jscs": "~2.8.0",
     "grunt-karma": "*",
     "grunt-newer": "^1.1.0",
     "grunt-ng-annotate": "^0.9.2",
     "grunt-ng-constant": "^2.0.1",
     "grunt-svgmin": "^2.0.0",
     "grunt-usemin": "^3.0.0",
+    "grunt-version": "1.1.1",
     "grunt-wiredep": "^2.0.0",
     "jit-grunt": "^0.9.1",
     "jshint-stylish": "^1.0.0",
     "karma-jasmine": "*",
     "karma-phantomjs-launcher": "*",
-    "time-grunt": "~1.0.0",
-    "grunt-version": "~1.1.1"
+    "time-grunt": "~1.0.0"
   },
   "engines": {
     "node": "4.4.5"


### PR DESCRIPTION
This adds two sanity checks for environment variables when doing a production build.  The Google Analytics token is specifically checked if it's falsy (that will disable Google Analytics on a production build).

Need to do an `npm install` before this will work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapventure/393)
<!-- Reviewable:end -->
