### PR TITLE
Fixes #335, ensure all polygon/multipolygon fires have a sane marker …

### DIFF
--- a/app/scripts/maps/alaska-wildfires/controller.js
+++ b/app/scripts/maps/alaska-wildfires/controller.js
@@ -161,10 +161,18 @@ app.controller('AlaskaWildfiresCtrl', [
         maxWidth: 200,
       };
       _.each(geoJson.features, function(feature) {
-        if (feature.geometry.type == 'Polygon') {
+        if (feature.geometry.type == 'Polygon' || feature.geometry.type == 'MultiPolygon') {
+
+          // If this is a MultiPolygon, we need to "flatten" the array
+          // of polygons into a single polygon before we can calculate
+          // the centroid.  The use of `[].concat.apply` accomplishes
+          // this flattening by concatenating the array of polygons.
+          var polygonCoordinates = (feature.geometry.type == 'MultiPolygon') ?
+            [].concat.apply([], feature.geometry.coordinates[0])
+            : feature.geometry.coordinates[0]
 
           // Reverse order from what we need
-          var coords = getCentroid2(feature.geometry.coordinates[0]);
+          var coords = getCentroid2(polygonCoordinates);
           var icon = isFireActive(feature.properties) ?
                 activeFireIcon : inactiveFireIcon;
 


### PR DESCRIPTION
…position

The problem was that the code never attempted to identify a marker position if the fire geometry type was `MultiPolygon`.  This change accounts for those geometries by "flattening" the array of polygons into a single polygon (not perfect, but works OK in practice!).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapventure/408)
<!-- Reviewable:end -->
